### PR TITLE
chore(datasets): auto-mount fastai public dataset

### DIFF
--- a/fastai-fastbook/Dockerfile
+++ b/fastai-fastbook/Dockerfile
@@ -1,4 +1,22 @@
 FROM fastdotai/fastai@sha256:4524c0f2a769a6f446986e61cfbd0d8421f9f8cee28a7a943044ddc2ed7c64d5
+
+# Ref the mild drama in
+#   https://github.com/pallets/jinja/issues/1626
+# and related threads
+#   https://github.com/pallets/jinja/issues/1636
+#   https://github.com/jupyter/nbconvert/pull/1737
+#   https://github.com/jupyter/nbconvert/issues/1736
+#   https://github.com/jupyter/nbconvert/issues/1605
+#
+# Jinja removed a previously-deprecated method that downstream
+# package maintainers weren't paying attention to and it breaks
+# Jupyter. Dust will settle in a couple days, but for now
+# we need to pin to a still-supported Jinja2 version
+RUN python3 -m pip install -I jinja2==3.0.3
+RUN python3 -m pip install --upgrade ipywidgets
+RUN python3 -m pip install --upgrade gradient
+RUN python3 -m pip install --upgrade jupyterlab
+
 ENV USER fastai
 WORKDIR /notebooks
 RUN chmod -R a+w /notebooks

--- a/fastai-fastbook/config.ini
+++ b/fastai-fastbook/config.ini
@@ -2,5 +2,5 @@
 
 archive = /storage/archive/
 model = /storage/models/
-data = /storage/data/
+data = /datasets/fastai/
 storage = /storage/data/

--- a/fastai-fastbook/run.sh
+++ b/fastai-fastbook/run.sh
@@ -4,4 +4,11 @@ export SHELL=/bin/bash
 mkdir /storage/data
 rm -rf /storage/lost+found
 ln -s /datasets/fastai/* /storage/data/
-jupyter notebook --ip=0.0.0.0 --no-browser --allow-root --NotebookApp.trust_xheaders=True --NotebookApp.disable_check_xsrf=False --NotebookApp.allow_remote_access=True --NotebookApp.allow_origin='*'
+
+mkdir /notebooks/.gradient
+echo "integrations:
+  fastai:
+    type: dataset
+    ref: paperspace/dsr4qbcrcg662pf:latest" > /notebooks/.gradient/settings.yaml
+
+jupyter lab --allow-root --ip=0.0.0.0 --no-browser --ServerApp.trust_xheaders=True --ServerApp.disable_check_xsrf=False --ServerApp.allow_remote_access=True --ServerApp.allow_origin='*' --ServerApp.allow_credentials=True


### PR DESCRIPTION
Verified that fastai dataset is auto-mounted:
![image](https://user-images.githubusercontent.com/89031899/160905067-eaf073fd-e423-4c6d-96db-980b3f1efc3d.png)

and that the path is being correctly set and referenced from the config file:
![image](https://user-images.githubusercontent.com/89031899/160905144-5bd601d3-820d-4bf7-bced-e5f7e5607f0c.png)
