### PR TITLE
chore(datasets): additional runtime compatibility with datasets

### DIFF
--- a/fastai-fastbook/Dockerfile
+++ b/fastai-fastbook/Dockerfile
@@ -12,10 +12,12 @@ FROM fastdotai/fastai@sha256:4524c0f2a769a6f446986e61cfbd0d8421f9f8cee28a7a94304
 # package maintainers weren't paying attention to and it breaks
 # Jupyter. Dust will settle in a couple days, but for now
 # we need to pin to a still-supported Jinja2 version
-RUN python3 -m pip install -I jinja2==3.0.3
-RUN python3 -m pip install --upgrade ipywidgets
+RUN python3 -m pip install -I jinja2>=3.1.1
+RUN python3 -m pip install --upgrade nbdev nbconvert jupyter jupyterlab
+RUN python3 -m pip install --upgrade fastai
 RUN python3 -m pip install --upgrade gradient
-RUN python3 -m pip install --upgrade jupyterlab
+RUN python3 -m pip install --upgrade ipywidgets
+
 
 ENV USER fastai
 WORKDIR /notebooks

--- a/fastai-fastbook/config.ini
+++ b/fastai-fastbook/config.ini
@@ -2,5 +2,5 @@
 
 archive = /storage/archive/
 model = /storage/models/
-data = /datasets/fastai/
+data = /storage/data
 storage = /storage/data/

--- a/fastai-fastbook/run.sh
+++ b/fastai-fastbook/run.sh
@@ -5,6 +5,21 @@ mkdir /storage/data
 rm -rf /storage/lost+found
 ln -s /datasets/fastai/* /storage/data/
 
+rm -f /storage/data/aclImdb
+rm -f /storage/data/adult_sample
+rm -f /storage/data/camvid_tiny
+rm -f /storage/data/dogscats
+rm -f /storage/data/human_numbers
+rm -f /storage/data/imagenet-sample-train
+rm -f /storage/data/ml-100k
+rm -f /storage/data/mnist_sample
+rm -f /storage/data/movie_lens_sample
+rm -f /storage/data/trn_resized_288.bc
+rm -f /storage/data/trn_resized_72.bc
+rm -f /storage/data/wt103_ids
+
+rm -f /storage/data/imdb_tok
+
 mkdir /notebooks/.gradient
 echo "integrations:
   fastai:


### PR DESCRIPTION
We have historically used `/storage/data` as a symlink pointing to
`/datasets`. This broke with the recent feature launch to allow dataset
mounting within notebooks: the fact that this dependency on the
now-replaced `/datasets` filepath existed in this runtime, and its
fragility, were not documented, and this was not shared knowledge.

This commit removed some lingering symlinks to now-nonexistent
`/datasets/fastai` references which had been causing errors within the
fastbook notebooks. It also reverts the `config.ini` update pointing the
datasets filepath to `/datasets/fastai` directly.

The fastai Python package requires the ability to write to whatever our
datasets filepath is, primarily to create intermediary datasets (e.g.,
as the result of work tokenization for NLP tasks). Since `/datasets` is
a readonly mount, we need to persist the `/storage/data` indirection
layer, so that we can continue to reference the automounted readonly
datasets while still allowing for system-writable paths to
other intermediary datasets.
