### PR TITLE
Update fastai runtime past recent breaking changes

### DIFF
--- a/fastai-fastbook/Dockerfile
+++ b/fastai-fastbook/Dockerfile
@@ -14,10 +14,11 @@ FROM fastdotai/fastai@sha256:4524c0f2a769a6f446986e61cfbd0d8421f9f8cee28a7a94304
 # we need to pin to a still-supported Jinja2 version
 RUN python3 -m pip install -I jinja2>=3.1.1
 RUN python3 -m pip install --upgrade nbdev nbconvert jupyter jupyterlab
-RUN python3 -m pip install --upgrade fastai
+RUN python3 -m pip install --upgrade fastai>=2.6.0
 RUN python3 -m pip install --upgrade gradient
 RUN python3 -m pip install --upgrade ipywidgets
-
+RUN python3 -m pip install --upgrade transformers[torch]
+RUN python3 -m pip install --upgrade fastbook
 
 ENV USER fastai
 WORKDIR /notebooks

--- a/fastai-fastbook/run.sh
+++ b/fastai-fastbook/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source activate fastai
 export SHELL=/bin/bash
-mkdir /storage/data
+mkdir -p /storage/data
 rm -rf /storage/lost+found
 ln -s /datasets/fastai/* /storage/data/
 


### PR DESCRIPTION
FastAI recently updated their Fastbook repo to use some Colab-specific syntax which broke users' ability to run notebooks top-to-bottom in our prior runtime. (There was a `!pip install fastbook` magic in the first cell of each notebook that no longer functions as expected on non-Colab platforms)

There were additional repo updates which require a newer version of the `fastai` Python package than was installed in our runtime. This commit addresses both issues by forcing an update past the minimum supported `fastai` package version and by preinstalling packages that are no longer installed for the user in the context of running the notebooks