### PR TITLE
chore: forward arguments to jupyter

### DIFF
--- a/fastai-fastbook/run.sh
+++ b/fastai-fastbook/run.sh
@@ -12,4 +12,4 @@ if [ -f /storage/pre-run.sh ]; then
     . /storage/pre-run.sh
 fi
 
-jupyter lab --allow-root --ip=0.0.0.0 --no-browser --ServerApp.trust_xheaders=True --ServerApp.disable_check_xsrf=False --ServerApp.allow_remote_access=True --ServerApp.allow_origin='*' --ServerApp.allow_credentials=True
+jupyter "$@"


### PR DESCRIPTION
This will allow us to update the flags without producing a new docker image. We will need to remember to update the start command in the runtimes table to include the flags when we release the next fast.ai image.